### PR TITLE
Build changes to support dynamic GOPATH when inside a project.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,15 @@
 # lists all the dependencies for test, prod and we can run a go build aftermath.
 ###############################################################################
 
+GOPATH  := $(GOPATH):$(shell pwd)/../../../../
+
+
 define HG_ERROR
 
 FATAL: you need mercurial (hg) to download cib dependencies.
        Check README.md for details
-       
-       
+
+
 endef
 
 define GIT_ERROR
@@ -49,7 +52,7 @@ ifndef GOPATH
 	@exit 1
 endif
 	@exit 0
-	
+
 get: hg git bzr get-code godep
 
 hg:
@@ -60,7 +63,7 @@ git:
 
 bzr:
 	$(if $(shell bzr), , $(error $(BZR_ERROR)))
-	
+
 get-code:
 	go get $(GO_EXTRAFLAGS) -u -d -t ./...
 


### PR DESCRIPTION
- The Makefile contains a GOPATH pointing to the currentworkspace as well. This means when doing development all the files under `~/code/megam/go` are used.
- During packaging all the files under `~/.go` and `~/<currentpackaging directory>` will be used. If the libraries like `github.com/megamsys/libgo` doesn't exists then it will be downloaded into `~/.go`.

Read the blog entry for more updates http://bit.ly/1pzjBpC
