### PR TITLE
Fix sudo chown command.

### DIFF
--- a/templates/ubuntu/tpl_ceph_install.go
+++ b/templates/ubuntu/tpl_ceph_install.go
@@ -143,7 +143,7 @@ func (m *UbuntuCephInstallTemplate) Render(pkg urknall.Package) {
 
 	pkg.AddCommands("mkdir_osd",
 		Mkdir(osddir,"", 0755),
-		Shell("sudo chown -R"+CephUser+":"+CephUser+" "+osddir ),
+		Shell("sudo chown -R "+CephUser+":"+CephUser+" "+osddir ),
 	)
 
 	pkg.AddCommands("write_cephconf",


### PR DESCRIPTION
no space after -R in chown command
